### PR TITLE
Adjust LGTM exclusion paths

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,8 +2,8 @@
 
 path_classifiers:
   library:
-    - exclude: "tweets/js/**"
-    - exclude: "tweets/lib/**"
+    - "tweets/js/**"
+    - "tweets/lib/**"
   generated:
-    - exclude: "tweets/data/**"
+    - "tweets/data/**"
 

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,7 +2,8 @@
 
 path_classifiers:
   library:
-    - exclude: tweets/js/
-    - exclude: tweets/lib/
+    - exclude: tweets/js/**
+    - exclude: tweets/lib/**
   generated:
-    - exclude: tweets/data/
+    - exclude: tweets/data/**
+

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,8 +2,8 @@
 
 path_classifiers:
   library:
-    - exclude: tweets/js/**
-    - exclude: tweets/lib/**
+    - exclude: "tweets/js/**"
+    - exclude: "tweets/lib/**"
   generated:
-    - exclude: tweets/data/**
+    - exclude: "tweets/data/**"
 

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,8 +2,8 @@
 
 path_classifiers:
   library:
-    - "tweets/js/**"
-    - "tweets/lib/**"
+    - tweets/js/
+    - tweets/lib/
   generated:
-    - "tweets/data/**"
+    - tweets/data/
 


### PR DESCRIPTION
Adjust exclusion paths because they are still triggering analysis warnings for library code.