### PR TITLE
Rename main branch

### DIFF
--- a/.github/workflows/build-github-pages.yml
+++ b/.github/workflows/build-github-pages.yml
@@ -5,9 +5,9 @@ name: build-github-pages
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   jekyll-build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 1 * * 4'
 


### PR DESCRIPTION
Update GitHub action definitions to use `main` branch after rename from master.
